### PR TITLE
Update destroyCache to track HAT not found status.

### DIFF
--- a/src/main/scala/org/hatdex/hat/api/services/HatSystem.scala
+++ b/src/main/scala/org/hatdex/hat/api/services/HatSystem.scala
@@ -57,6 +57,9 @@ trait HatSystem {
     futureResponse.flatMap { response =>
       response.status match {
         case OK => Future.successful(())
+        case NOT_FOUND =>
+          logger.error(s"Destroying $hatAddress cache failed - HAT NOT FOUND, $response, ${response.body}")
+          Future.failed(new RuntimeException(s"Destroying $hatAddress cache failed - HAT NOT FOUnD"))
         case _ =>
           logger.error(s"Destroying $hatAddress cache failed, $response, ${response.body}")
           Future.failed(new RuntimeException(s"Destroying $hatAddress cache failed"))


### PR DESCRIPTION
So that milliner can continue even if HAT db is not found during a destroy-cache call.